### PR TITLE
return empty string and nil error if content-type is empty so that en…

### DIFF
--- a/header.go
+++ b/header.go
@@ -226,6 +226,9 @@ func ParseMediaType(ctype string) (mtype string, params map[string]string, inval
 	if err != nil {
 		// Small hack to remove harmless charset duplicate params.
 		mctype := fixMangledMediaType(ctype, ";")
+		if mctype == "" {
+			return "", nil, nil, nil
+		}
 		mtype, params, err = mime.ParseMediaType(mctype)
 		if err != nil {
 			// Some badly formed media types forget to send ; between fields.


### PR DESCRIPTION
…mime.ErrorMissingContentType can be added to the errors slice and continue parsing