### PR TITLE
Requaos/unquoted boundary

### DIFF
--- a/header.go
+++ b/header.go
@@ -400,8 +400,6 @@ findValueStart:
 	} else {
 		// The beginning of the value is not at the end of the string
 
-		s = s[i+1:]
-
 		quoteIfUnquoted := func() {
 			if !valueQuoteNeeded {
 				if !valueQuoteAdded {
@@ -413,6 +411,14 @@ findValueStart:
 				valueQuoteNeeded = true
 			}
 		}
+
+		for _, v := range []byte{'(', ')', '<', '>', '@', ',', ':', '/', '[', ']', '?', '='} {
+			if s[0] == v {
+				quoteIfUnquoted()
+			}
+		}
+
+		s = s[i+1:]
 
 	findValueEnd:
 		for len(s) > 0 {

--- a/header_test.go
+++ b/header_test.go
@@ -324,6 +324,10 @@ func TestFixUnquotedSpecials(t *testing.T) {
 			want:  "application/octet-stream; param1=\"value/1\"",
 		},
 		{
+			input: "multipart/alternative; boundary=?UOAwFjScLp1is-162467503201177404728935166502-",
+			want:  "multipart/alternative; boundary=\"?UOAwFjScLp1is-162467503201177404728935166502-\"",
+		},
+		{
 			input: `text/HTML; charset="UTF-8Return-Path: bounce-810_HTML-769869545-477063-1070564-43@bounce.email.oflce57578375.com`,
 			want:  `text/HTML; charset="UTF-8Return-Path: bounce-810_HTML-769869545-477063-1070564-43@bounce.email.oflce57578375.com"`,
 		},


### PR DESCRIPTION
Found that our code for checking if a media parameter value needs to be quoted, was not checking the first character of the media parameter value. This merge resolves this issue